### PR TITLE
Fix error buffer for SSL errors

### DIFF
--- a/src/pwenc/pwenc_decrypt.c
+++ b/src/pwenc/pwenc_decrypt.c
@@ -32,8 +32,7 @@ static pwenc_resp_t do_decrypt(pwenc_ctx_t *ctx, const pwenc_datum_t *nonce,
 
 	if (EVP_DecryptInit_ex(cipher_ctx, EVP_aes_256_ctr(), NULL, ctx->secret_mem,
 	    iv) != 1) {
-		pwenc_set_error(error, "EVP_DecryptInit_ex() failed: %s",
-			ERR_error_string(ERR_get_error(), NULL));
+		pwenc_set_ssl_error(error, "EVP_DecryptInit_ex() failed");
 		ret = PWENC_ERROR_CRYPTO;
 		goto cleanup;
 	}
@@ -47,8 +46,7 @@ static pwenc_resp_t do_decrypt(pwenc_ctx_t *ctx, const pwenc_datum_t *nonce,
 
 	if (EVP_DecryptUpdate(cipher_ctx, plaintext.data, &len, ciphertext->data,
 	    ciphertext->size) != 1) {
-		pwenc_set_error(error, "EVP_DecryptUpdate() failed: %s",
-			ERR_error_string(ERR_get_error(), NULL));
+		pwenc_set_ssl_error(error, "EVP_DecryptUpdate() failed");
 		ret = PWENC_ERROR_CRYPTO;
 		goto cleanup;
 	}
@@ -56,8 +54,7 @@ static pwenc_resp_t do_decrypt(pwenc_ctx_t *ctx, const pwenc_datum_t *nonce,
 	plaintext.size = len;
 
 	if (EVP_DecryptFinal_ex(cipher_ctx, plaintext.data + len, &len) != 1) {
-		pwenc_set_error(error, "EVP_DecryptFinal_ex() failed: %s",
-			ERR_error_string(ERR_get_error(), NULL));
+		pwenc_set_ssl_error(error, "EVP_DecryptFinal_ex() failed");
 		ret = PWENC_ERROR_CRYPTO;
 		goto cleanup;
 	}

--- a/src/pwenc/pwenc_open.c
+++ b/src/pwenc/pwenc_open.c
@@ -25,8 +25,7 @@ static pwenc_resp_t generate_secret_file(const char *path, pwenc_error_t *error)
 
 	// generate the random bytes
 	if (RAND_bytes(secret, PWENC_BLOCK_SIZE) != 1) {
-		pwenc_set_error(error, "RAND_bytes() failed: %s",
-			ERR_error_string(ERR_get_error(), NULL));
+		pwenc_set_ssl_error(error, "RAND_bytes() failed");
 		return PWENC_ERROR_CRYPTO;
 	}
 

--- a/src/pwenc/pwenc_private.h
+++ b/src/pwenc/pwenc_private.h
@@ -20,18 +20,23 @@ struct pwenc_ctx {
  * @brief set error message in error struct with location info
  *
  * @param[in]	error - error struct to set message in (may be NULL)
+ * @param[in]	ssl_err_code - SSL error code (0 if no SSL error)
  * @param[in]	fmt - printf-style format string
+ * @param[in]	location - location string
  * @param[in]	... - format arguments
  */
-void _pwenc_set_error(pwenc_error_t *error, const char *fmt,
-	const char *location, ...);
+void _pwenc_set_error(pwenc_error_t *error, unsigned long ssl_err_code,
+	const char *fmt, const char *location, ...);
 
 #define __stringify(x) #x
 #define __stringify2(x) __stringify(x)
 #define __location__ __FILE__ ":" __stringify2(__LINE__)
 
 #define pwenc_set_error(error, fmt, ...) \
-	_pwenc_set_error(error, fmt, __location__, ##__VA_ARGS__)
+	_pwenc_set_error(error, 0, fmt, __location__, ##__VA_ARGS__)
+
+#define pwenc_set_ssl_error(error, fmt, ...) \
+	_pwenc_set_error(error, ERR_get_error(), fmt, __location__, ##__VA_ARGS__)
 
 /*
  * Macro for pwenc_datum_t validation

--- a/src/pwenc/pwenc_utils.c
+++ b/src/pwenc/pwenc_utils.c
@@ -44,7 +44,7 @@ pwenc_resp_t base64_encode(pwenc_error_t *error, const pwenc_datum_t *data_in,
 
 	ret = EVP_EncodeBlock((unsigned char *)encoded, data_in->data, data_in->size);
 	if (ret < 0) {
-		pwenc_set_error(error, "EVP_EncodeBlock() failed");
+		pwenc_set_ssl_error(error, "EVP_EncodeBlock() failed to base64 encode data");
 		free(encoded);
 		return PWENC_ERROR_CRYPTO;
 	}
@@ -75,7 +75,7 @@ pwenc_resp_t base64_decode(pwenc_error_t *error, const pwenc_datum_t *data_in,
 	decoded_len = EVP_DecodeBlock(decoded, data_in->data, data_in->size);
 	if (decoded_len < 0) {
 		free(decoded);
-		pwenc_set_error(error, "EVP_DecodeBlock() failed");
+		pwenc_set_ssl_error(error, "EVP_DecodeBlock() failed to base64 decode data");
 		return PWENC_ERROR_CRYPTO;
 	}
 


### PR DESCRIPTION
This commit fixes error message handling that wasn't MT-safe due to using a default static buffer in openssl.