### PR TITLE
NAS-139407 / 26.04 / Add watch parameter to pwenc

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The TrueNAS pwenc library consists of:
 - **AES-256-CTR encryption** with random 8-byte nonces
 - **Base64 encoding** for safe text storage
 - **Secure memory handling** using memfd_secret
+- **Automatic secret reloading** via inotify file watching
 - **Python bindings** for easy integration
 
 ## Architecture
@@ -27,6 +28,9 @@ The library uses a context-based approach where operations are performed through
 - `PWENC_ERROR_CRYPTO` (-3) - Cryptographic operation failure
 - `PWENC_ERROR_IO` (-4) - I/O operation failure
 - `PWENC_ERROR_SECRET_NOT_FOUND` (-5) - Secret file not found
+- `PWENC_ERROR_PAYLOAD_TOO_LARGE` (-6) - Payload exceeds maximum size
+- `PWENC_ERROR_WATCH_FAILED` (-7) - Failed to setup inotify watch
+- `PWENC_ERROR_SECRET_RELOAD_FAILED` (-8) - Failed to reload secret file
 
 ## Building
 
@@ -66,9 +70,88 @@ make install
 pip install .
 ```
 
+## Usage
+
+### Python API
+
+```python
+import truenas_pypwenc
+
+# Create a context with automatic secret file creation
+ctx = truenas_pypwenc.get_context(create=True)
+
+# Encrypt data
+plaintext = b"sensitive data"
+encrypted = ctx.encrypt(plaintext)
+
+# Decrypt data
+decrypted = ctx.decrypt(encrypted)
+assert decrypted == plaintext
+```
+
+### Automatic Secret Reloading
+
+Enable inotify watching to automatically reload the secret when the file changes:
+
+```python
+import truenas_pypwenc
+
+# Create context with watch enabled
+ctx = truenas_pypwenc.get_context(watch=True, secret_path="/data/pwenc_secret")
+
+# Check if watching is active
+print(ctx.watching)  # True
+
+# Encrypt/decrypt operations will automatically reload the secret
+# if the file is modified, deleted, or replaced (atomic rename)
+encrypted = ctx.encrypt(b"data")
+decrypted = ctx.decrypt(encrypted)
+```
+
+The watch feature monitors the secret file for:
+- **File modifications** (`IN_MODIFY`)
+- **File deletion** (`IN_DELETE_SELF`)
+- **File moves** (`IN_MOVE_SELF`)
+- **Atomic replacements** (rename over the file path)
+
+When any of these events occur, the next encrypt/decrypt operation will:
+1. Check for inotify events (non-blocking)
+2. Reload the secret from disk if changes detected
+3. Proceed with the operation
+
+### C API
+
+```c
+#include <truenas_pwenc.h>
+
+pwenc_ctx_t *ctx;
+pwenc_error_t error;
+bool created;
+
+// Initialize context with watch enabled
+int ret = pwenc_init_context("/data/pwenc_secret",
+                              PWENC_OPEN_CREATE | PWENC_OPEN_WATCH,
+                              &ctx, &created, &error);
+
+// Check if watching is active
+if (pwenc_is_watching(ctx)) {
+    // Automatic reload on file changes
+}
+
+// Encrypt/decrypt operations
+pwenc_datum_t plaintext = {.data = "secret", .size = 6};
+pwenc_datum_t ciphertext;
+ret = pwenc_encrypt(ctx, &plaintext, &ciphertext, &error);
+
+// Cleanup
+pwenc_free_context(ctx);
+```
+
 ## Configuration
 
 The default secret file location is `/data/pwenc_secret`. This can be overridden when opening a context.
+
+Environment variable `FREENAS_PWENC_SECRET` can also be used to specify the secret file path.
 
 ## License
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ truenas_pypwenc_ext = Extension(
         'src/pwenc/pwenc_close.c',
         'src/pwenc/pwenc_encrypt.c',
         'src/pwenc/pwenc_decrypt.c',
-        'src/pwenc/pwenc_utils.c'
+        'src/pwenc/pwenc_utils.c',
+        'src/pwenc/pwenc_watch.c'
     ],
     include_dirs=['src/pwenc', 'src/pypwenc'],
     libraries=['ssl', 'crypto', 'bsd']

--- a/src/pwenc/pwenc_close.c
+++ b/src/pwenc/pwenc_close.c
@@ -11,6 +11,10 @@ void pwenc_close(pwenc_ctx_t *ctx)
 		return;
 	}
 
+	if (ctx->watching) {
+		pwenc_cleanup_watch(ctx);
+	}
+
 	if (ctx->secret_mem != NULL) {
 		munmap(ctx->secret_mem, PWENC_BLOCK_SIZE);
 	}

--- a/src/pwenc/pwenc_context.c
+++ b/src/pwenc/pwenc_context.c
@@ -35,6 +35,10 @@ pwenc_resp_t pwenc_init_context(const char *secret_path,
 
 	new_ctx->memfd = -1;
 	new_ctx->secret_mem = NULL;
+	new_ctx->inotify_fd = -1;
+	new_ctx->file_watch_wd = -1;
+	new_ctx->dir_watch_wd = -1;
+	new_ctx->watching = false;
 
 	/*
 	 * For compatiblity with legacy middleware behavior we allow overriding secret
@@ -53,6 +57,35 @@ pwenc_resp_t pwenc_init_context(const char *secret_path,
 		return PWENC_ERROR_INVALID_INPUT;
 	}
 
+	/* Require absolute path for security and watch functionality */
+	if (new_ctx->secret_path[0] != '/') {
+		pwenc_set_error(error, "Secret path must be absolute (start with '/')");
+		free(new_ctx);
+		return PWENC_ERROR_INVALID_INPUT;
+	}
+
+	/* Initialize watch-related fields if watching is requested */
+	if (flags & PWENC_OPEN_WATCH) {
+		char *last_slash;
+
+		pthread_mutex_init(&new_ctx->watch_mutex, NULL);
+
+		/* Parse directory path and filename */
+		strlcpy(new_ctx->dir_path, new_ctx->secret_path, sizeof(new_ctx->dir_path));
+		last_slash = strrchr(new_ctx->dir_path, '/');
+		if (!last_slash) {
+			pwenc_set_error(error, "Secret path must be absolute (contain '/')");
+			pthread_mutex_destroy(&new_ctx->watch_mutex);
+			free(new_ctx);
+			return PWENC_ERROR_INVALID_INPUT;
+		}
+
+		/* Copy filename from position after the slash */
+		strlcpy(new_ctx->filename, last_slash + 1, sizeof(new_ctx->filename));
+		/* Null-terminate dir_path at the slash */
+		*last_slash = '\0';
+	}
+
 	resp = pwenc_open(new_ctx, flags, created, error);
 	if (resp != PWENC_SUCCESS) {
 		pwenc_free_context(new_ctx);
@@ -69,6 +102,9 @@ void pwenc_free_context(pwenc_ctx_t *ctx)
 		return;
 	}
 	pwenc_close(ctx);
+	if (ctx->watching) {
+		pthread_mutex_destroy(&ctx->watch_mutex);
+	}
 	free(ctx);
 }
 

--- a/src/pwenc/pwenc_decrypt.c
+++ b/src/pwenc/pwenc_decrypt.c
@@ -100,6 +100,16 @@ pwenc_resp_t pwenc_decrypt(pwenc_ctx_t *ctx, const pwenc_datum_t *data_in,
 		return PWENC_ERROR_PAYLOAD_TOO_LARGE;
 	}
 
+	/* Check for secret updates if watching is enabled */
+	if (ctx->watching) {
+		pthread_mutex_lock(&ctx->watch_mutex);
+		ret = pwenc_check_and_reload(ctx, error);
+		pthread_mutex_unlock(&ctx->watch_mutex);
+		if (ret != PWENC_SUCCESS) {
+			return ret;
+		}
+	}
+
 	ret = base64_decode(error, data_in, &decoded_datum);
 	if (ret != PWENC_SUCCESS) {
 		return ret;

--- a/src/pwenc/pwenc_encrypt.c
+++ b/src/pwenc/pwenc_encrypt.c
@@ -117,6 +117,16 @@ pwenc_resp_t pwenc_encrypt(pwenc_ctx_t *ctx, const pwenc_datum_t *data_in,
 		return PWENC_ERROR_PAYLOAD_TOO_LARGE;
 	}
 
+	/* Check for secret updates if watching is enabled */
+	if (ctx->watching) {
+		pthread_mutex_lock(&ctx->watch_mutex);
+		ret = pwenc_check_and_reload(ctx, error);
+		pthread_mutex_unlock(&ctx->watch_mutex);
+		if (ret != PWENC_SUCCESS) {
+			return ret;
+		}
+	}
+
 	ret = pwenc_create_nonce(&nonce, error);
 	if (ret != PWENC_SUCCESS) {
 		goto cleanup;

--- a/src/pwenc/pwenc_open.c
+++ b/src/pwenc/pwenc_open.c
@@ -178,5 +178,10 @@ pwenc_resp_t pwenc_open(pwenc_ctx_t *ctx, int flags, bool *created, pwenc_error_
 		}
 	}
 
+	/* Setup inotify watch if requested and secret was loaded successfully */
+	if ((ret == PWENC_SUCCESS) && (flags & PWENC_OPEN_WATCH)) {
+		ret = pwenc_setup_watch(ctx, error);
+	}
+
 	return ret;
 }

--- a/src/pwenc/pwenc_private.h
+++ b/src/pwenc/pwenc_private.h
@@ -5,6 +5,7 @@
 #include "truenas_pwenc.h"
 #include <limits.h>
 #include <sys/param.h>
+#include <pthread.h>
 
 #include <openssl/rand.h>
 #include <openssl/err.h>
@@ -14,6 +15,19 @@ struct pwenc_ctx {
 	int memfd;
 	void *secret_mem;
 	char secret_path[PATH_MAX];
+
+	// inotify state (only if PWENC_OPEN_WATCH was set)
+	int inotify_fd;              // -1 when not watching
+	int file_watch_wd;           // Watch descriptor for the file itself
+	int dir_watch_wd;            // Watch descriptor for parent directory
+	char dir_path[PATH_MAX];     // Parent directory path
+	char filename[NAME_MAX + 1]; // Just the filename (basename)
+
+	// Mutex for checking and reloading (only used if watching)
+	pthread_mutex_t watch_mutex;
+
+	// State flags
+	bool watching;               // True when watch is active (immutable after init)
 };
 
 /*
@@ -107,5 +121,41 @@ pwenc_resp_t pwenc_open(pwenc_ctx_t *ctx, int flags, bool *created, pwenc_error_
  * @param[in]   ctx - pointer to context structure to cleanup
  */
 void pwenc_close(pwenc_ctx_t *ctx);
+
+/*
+ * @brief setup inotify watch on secret file
+ *
+ * This function creates an inotify instance and sets up watches on both
+ * the secret file itself (inode-level) and its parent directory (path-level)
+ * to catch rename-over operations.
+ *
+ * @param[in]   ctx - pointer to context structure
+ * @param[out]  error - pointer to error structure for error details
+ *
+ * @return      PWENC_SUCCESS on success, PWENC_ERROR_WATCH_FAILED on failure
+ */
+pwenc_resp_t pwenc_setup_watch(pwenc_ctx_t *ctx, pwenc_error_t *error);
+
+/*
+ * @brief cleanup inotify watch
+ *
+ * This function removes inotify watches and closes the inotify file descriptor.
+ *
+ * @param[in]   ctx - pointer to context structure
+ */
+void pwenc_cleanup_watch(pwenc_ctx_t *ctx);
+
+/*
+ * @brief check for file changes and reload secret if necessary
+ *
+ * This function reads inotify events (non-blocking) and reloads the secret
+ * in-place if the file has been deleted, moved, or modified.
+ *
+ * @param[in]   ctx - pointer to context structure
+ * @param[out]  error - pointer to error structure for error details
+ *
+ * @return      PWENC_SUCCESS on success, error code on failure
+ */
+pwenc_resp_t pwenc_check_and_reload(pwenc_ctx_t *ctx, pwenc_error_t *error);
 
 #endif

--- a/src/pwenc/pwenc_watch.c
+++ b/src/pwenc/pwenc_watch.c
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+#define _GNU_SOURCE
+#include "truenas_pwenc.h"
+#include "pwenc_private.h"
+
+#include <errno.h>
+#include <string.h>
+#include <sys/inotify.h>
+#include <unistd.h>
+
+#define EVENT_SIZE (sizeof(struct inotify_event))
+#define EVENT_BUF_LEN 4096
+
+/*
+ * Check if an inotify event requires reloading the secret.
+ * Returns true if the event indicates the secret file has changed.
+ */
+static bool event_needs_reload(pwenc_ctx_t *ctx, struct inotify_event *event)
+{
+	// File-level events (inode changes)
+	if (event->wd == ctx->file_watch_wd) {
+		if (event->mask & (IN_DELETE_SELF | IN_MOVE_SELF | IN_MODIFY)) {
+			return true;
+		}
+	}
+
+	// Directory-level events (rename-over case)
+	if (event->wd == ctx->dir_watch_wd) {
+		if ((event->mask & (IN_CREATE | IN_MOVED_TO)) &&
+		    event->len > 0 &&
+		    strcmp(event->name, ctx->filename) == 0) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/*
+ * Reload the secret from the file at secret_path into the context.
+ * This closes the old secret and loads the new one.
+ */
+static pwenc_resp_t pwenc_reload_secret(pwenc_ctx_t *ctx, pwenc_error_t *error)
+{
+	pwenc_resp_t ret;
+	bool created;
+
+	// Clean up old secret
+	pwenc_close(ctx);
+
+	// Load new secret using existing open function
+	ret = pwenc_open(ctx, PWENC_OPEN_EXISTING, &created, error);
+	if (ret != PWENC_SUCCESS) {
+		return PWENC_ERROR_SECRET_RELOAD_FAILED;
+	}
+
+	return PWENC_SUCCESS;
+}
+
+pwenc_resp_t pwenc_check_and_reload(pwenc_ctx_t *ctx, pwenc_error_t *error)
+{
+	char buf[EVENT_BUF_LEN];
+	ssize_t len;
+	struct inotify_event *event;
+	bool needs_reload = false;
+
+	// Keep reading events until queue is empty or we find a reload trigger
+	while (!needs_reload) {
+		// Non-blocking read of inotify events
+		len = read(ctx->inotify_fd, buf, sizeof(buf));
+
+		if (len < 0) {
+			if (errno == EAGAIN || errno == EWOULDBLOCK) {
+				break;  // No more events
+			}
+			pwenc_set_error(error, "read() from inotify fd failed: %s", strerror(errno));
+			return PWENC_ERROR_IO;
+		}
+
+		// Process events in this read
+		for (char *ptr = buf; ptr < buf + len; ) {
+			event = (struct inotify_event *)ptr;
+
+			needs_reload = event_needs_reload(ctx, event);
+			if (needs_reload) {
+				break;
+			}
+
+			ptr += EVENT_SIZE + event->len;
+		}
+	}
+
+	if (needs_reload) {
+		return pwenc_reload_secret(ctx, error);
+	}
+
+	return PWENC_SUCCESS;
+}
+
+pwenc_resp_t pwenc_setup_watch(pwenc_ctx_t *ctx, pwenc_error_t *error)
+{
+	int fd, file_wd, dir_wd;
+
+	// Create inotify instance
+	fd = inotify_init1(IN_NONBLOCK | IN_CLOEXEC);
+	if (fd < 0) {
+		pwenc_set_error(error, "inotify_init1() failed: %s", strerror(errno));
+		return PWENC_ERROR_WATCH_FAILED;
+	}
+
+	// Watch the file itself (inode-level)
+	file_wd = inotify_add_watch(fd, ctx->secret_path,
+		IN_DELETE_SELF | IN_MOVE_SELF | IN_MODIFY | IN_ATTRIB);
+	if (file_wd < 0) {
+		pwenc_set_error(error, "inotify_add_watch() on file failed: %s", strerror(errno));
+		close(fd);
+		return PWENC_ERROR_WATCH_FAILED;
+	}
+
+	// Watch the parent directory (path-level for rename-over)
+	dir_wd = inotify_add_watch(fd, ctx->dir_path,
+		IN_CREATE | IN_MOVED_TO);
+	if (dir_wd < 0) {
+		pwenc_set_error(error, "inotify_add_watch() on directory failed: %s", strerror(errno));
+		inotify_rm_watch(fd, file_wd);
+		close(fd);
+		return PWENC_ERROR_WATCH_FAILED;
+	}
+
+	ctx->inotify_fd = fd;
+	ctx->file_watch_wd = file_wd;
+	ctx->dir_watch_wd = dir_wd;
+	ctx->watching = true;
+
+	return PWENC_SUCCESS;
+}
+
+void pwenc_cleanup_watch(pwenc_ctx_t *ctx)
+{
+	if (!ctx) {
+		return;
+	}
+
+	if (ctx->file_watch_wd >= 0 && ctx->inotify_fd >= 0) {
+		inotify_rm_watch(ctx->inotify_fd, ctx->file_watch_wd);
+		ctx->file_watch_wd = -1;
+	}
+
+	if (ctx->dir_watch_wd >= 0 && ctx->inotify_fd >= 0) {
+		inotify_rm_watch(ctx->inotify_fd, ctx->dir_watch_wd);
+		ctx->dir_watch_wd = -1;
+	}
+
+	if (ctx->inotify_fd >= 0) {
+		close(ctx->inotify_fd);
+		ctx->inotify_fd = -1;
+	}
+}
+
+bool pwenc_is_watching(pwenc_ctx_t *ctx)
+{
+	return ctx && ctx->watching;
+}

--- a/src/pwenc/truenas_pwenc.h
+++ b/src/pwenc/truenas_pwenc.h
@@ -18,9 +18,12 @@
 #define PWENC_ERROR_IO -4
 #define PWENC_ERROR_SECRET_NOT_FOUND -5
 #define PWENC_ERROR_PAYLOAD_TOO_LARGE -6
+#define PWENC_ERROR_WATCH_FAILED -7
+#define PWENC_ERROR_SECRET_RELOAD_FAILED -8
 
 #define PWENC_OPEN_EXISTING 0
 #define PWENC_OPEN_CREATE O_CREAT
+#define PWENC_OPEN_WATCH 0x04
 
 #define PWENC_DEFAULT_SECRET_PATH "/data/pwenc_secret"
 
@@ -116,5 +119,14 @@ pwenc_resp_t pwenc_encrypt(pwenc_ctx_t *ctx, const pwenc_datum_t *data_in,
  */
 pwenc_resp_t pwenc_decrypt(pwenc_ctx_t *ctx, const pwenc_datum_t *data_in,
 	pwenc_datum_t *data_out, pwenc_error_t *error);
+
+/*
+ * @brief check if inotify watching is active on a context
+ *
+ * @param[in]	ctx - initialized context
+ *
+ * @return	true if watching is active, false otherwise
+ */
+bool pwenc_is_watching(pwenc_ctx_t *ctx);
 
 #endif

--- a/src/pypwenc/error.c
+++ b/src/pypwenc/error.c
@@ -34,6 +34,10 @@ const char *pwenc_error_code_to_string(pwenc_resp_t code)
 		return "PWENC_ERROR_SECRET_NOT_FOUND";
 	case PWENC_ERROR_PAYLOAD_TOO_LARGE:
 		return "PWENC_ERROR_PAYLOAD_TOO_LARGE";
+	case PWENC_ERROR_WATCH_FAILED:
+		return "PWENC_ERROR_WATCH_FAILED";
+	case PWENC_ERROR_SECRET_RELOAD_FAILED:
+		return "PWENC_ERROR_SECRET_RELOAD_FAILED";
 	default:
 		return "PWENC_ERROR_UNKNOWN";
 	}

--- a/src/pypwenc/truenas_pypwenc.c
+++ b/src/pypwenc/truenas_pypwenc.c
@@ -344,5 +344,49 @@ PyInit_truenas_pypwenc(void)
 		return NULL;
 	}
 
+	/* Add error code constants */
+	if (PyModule_AddIntConstant(m, "PWENC_SUCCESS", PWENC_SUCCESS) < 0) {
+		Py_DECREF(m);
+		return NULL;
+	}
+	if (PyModule_AddIntConstant(m, "PWENC_ERROR_INVALID_INPUT", PWENC_ERROR_INVALID_INPUT) < 0) {
+		Py_DECREF(m);
+		return NULL;
+	}
+	if (PyModule_AddIntConstant(m, "PWENC_ERROR_MEMORY", PWENC_ERROR_MEMORY) < 0) {
+		Py_DECREF(m);
+		return NULL;
+	}
+	if (PyModule_AddIntConstant(m, "PWENC_ERROR_CRYPTO", PWENC_ERROR_CRYPTO) < 0) {
+		Py_DECREF(m);
+		return NULL;
+	}
+	if (PyModule_AddIntConstant(m, "PWENC_ERROR_IO", PWENC_ERROR_IO) < 0) {
+		Py_DECREF(m);
+		return NULL;
+	}
+	if (PyModule_AddIntConstant(m, "PWENC_ERROR_SECRET_NOT_FOUND", PWENC_ERROR_SECRET_NOT_FOUND) < 0) {
+		Py_DECREF(m);
+		return NULL;
+	}
+	if (PyModule_AddIntConstant(m, "PWENC_ERROR_PAYLOAD_TOO_LARGE", PWENC_ERROR_PAYLOAD_TOO_LARGE) < 0) {
+		Py_DECREF(m);
+		return NULL;
+	}
+	if (PyModule_AddIntConstant(m, "PWENC_ERROR_WATCH_FAILED", PWENC_ERROR_WATCH_FAILED) < 0) {
+		Py_DECREF(m);
+		return NULL;
+	}
+	if (PyModule_AddIntConstant(m, "PWENC_ERROR_SECRET_RELOAD_FAILED", PWENC_ERROR_SECRET_RELOAD_FAILED) < 0) {
+		Py_DECREF(m);
+		return NULL;
+	}
+
+	/* Add buffer size constant */
+	if (PyModule_AddIntConstant(m, "PWENC_BLOCK_SIZE", PWENC_BLOCK_SIZE) < 0) {
+		Py_DECREF(m);
+		return NULL;
+	}
+
 	return m;
 }

--- a/src/pypwenc/truenas_pypwenc.c
+++ b/src/pypwenc/truenas_pypwenc.c
@@ -129,6 +129,12 @@ py_pwenc_ctx_get_path(py_pwenc_ctx_t *self, void *closure)
 }
 
 static PyObject *
+py_pwenc_ctx_get_watching(py_pwenc_ctx_t *self, void *closure)
+{
+	return Py_NewRef(pwenc_is_watching(self->ctx) ? Py_True : Py_False);
+}
+
+static PyObject *
 py_pwenc_ctx_repr(py_pwenc_ctx_t *self)
 {
 	const char *path = pwenc_get_secret_path(self->ctx);
@@ -148,6 +154,11 @@ static PyGetSetDef py_pwenc_ctx_getsetters[] = {
 		.name = "path",
 		.get = (getter)py_pwenc_ctx_get_path,
 		.doc = "Path to the secret file used by this context"
+	},
+	{
+		.name = "watching",
+		.get = (getter)py_pwenc_ctx_get_watching,
+		.doc = "True if inotify watching is active on the secret file"
 	},
 	{NULL}
 };
@@ -192,13 +203,17 @@ static PyTypeObject PwencContextType = {
 };
 
 PyDoc_STRVAR(get_context__doc__,
-"get_context(*, create=False, secret_path=None) -> truenas_pypwenc.PwencContext\n"
-"----------------------------------------------------------------------------\n\n"
+"get_context(*, create=False, watch=False, secret_path=None) -> truenas_pypwenc.PwencContext\n"
+"-------------------------------------------------------------------------------------------\n\n"
 "Create a new PwencContext instance for encryption and decryption operations.\n\n"
 "Parameters\n"
 "----------\n"
 "create: bool, optional (default=False)\n"
 "    Whether to create a new secret file if one doesn't exist.\n"
+"watch: bool, optional (default=False)\n"
+"    Whether to enable inotify watching on the secret file for automatic\n"
+"    reload on changes. When enabled, encrypt/decrypt will check for file\n"
+"    changes and reload the secret transparently.\n"
 "secret_path: str, optional (default=None)\n"
 "    Path to secret file. If None, uses FREENAS_PWENC_SECRET environment\n"
 "    variable or falls back to /data/pwenc_secret.\n\n"
@@ -214,13 +229,14 @@ get_context(PyObject *self, PyObject *args, PyObject *kwds)
 	py_pwenc_ctx_t *ctx;
 	int flags = PWENC_OPEN_EXISTING;
 	int create = 0;
+	int watch = 0;
 	const char *secret_path = NULL;
 	pwenc_error_t error = {0};
 	pwenc_resp_t ret;
 
-	static char *kwlist[] = {"create", "secret_path", NULL};
+	static char *kwlist[] = {"create", "watch", "secret_path", NULL};
 
-	if (!PyArg_ParseTupleAndKeywords(args, kwds, "|ps", kwlist, &create, &secret_path))
+	if (!PyArg_ParseTupleAndKeywords(args, kwds, "|pps", kwlist, &create, &watch, &secret_path))
 		return NULL;
 
 	ctx = (py_pwenc_ctx_t *)PyObject_CallObject((PyObject *)&PwencContextType, NULL);
@@ -231,6 +247,9 @@ get_context(PyObject *self, PyObject *args, PyObject *kwds)
 
 	if (create) {
 		flags |= PWENC_OPEN_CREATE;
+	}
+	if (watch) {
+		flags |= PWENC_OPEN_WATCH;
 	}
 
 	Py_BEGIN_ALLOW_THREADS

--- a/stubs/__init__.pyi
+++ b/stubs/__init__.pyi
@@ -44,6 +44,11 @@ class PwencContext:
         """Path to the secret file used by this context"""
         ...
 
+    @property
+    def watching(self) -> bool:
+        """True if inotify watching is active on the secret file"""
+        ...
+
     def encrypt(self, data: bytes) -> bytes:
         """
         Encrypt data using AES-256-CTR and encode as base64.
@@ -89,6 +94,7 @@ class PwencContext:
 def get_context(
     *,
     create: bool = False,
+    watch: bool = False,
     secret_path: Optional[str] = None
 ) -> PwencContext:
     """
@@ -98,6 +104,11 @@ def get_context(
     ----------
     create : bool, optional
         Whether to create a new secret file if one doesn't exist.
+        Default is False.
+    watch : bool, optional
+        Whether to enable inotify watching on the secret file for automatic
+        reload on changes. When enabled, encrypt/decrypt will check for file
+        changes and reload the secret transparently.
         Default is False.
     secret_path : str, optional
         Path to secret file. If None, uses FREENAS_PWENC_SECRET environment

--- a/stubs/__init__.pyi
+++ b/stubs/__init__.pyi
@@ -7,9 +7,38 @@ stored in memfd_secret for enhanced security.
 
 from typing import Optional
 
-__all__ = ['PwencContext', 'PwencError', 'get_context', 'DEFAULT_SECRET_PATH']
+__all__ = [
+    'PwencContext',
+    'PwencError',
+    'get_context',
+    'DEFAULT_SECRET_PATH',
+    'PWENC_SUCCESS',
+    'PWENC_ERROR_INVALID_INPUT',
+    'PWENC_ERROR_MEMORY',
+    'PWENC_ERROR_CRYPTO',
+    'PWENC_ERROR_IO',
+    'PWENC_ERROR_SECRET_NOT_FOUND',
+    'PWENC_ERROR_PAYLOAD_TOO_LARGE',
+    'PWENC_ERROR_WATCH_FAILED',
+    'PWENC_ERROR_SECRET_RELOAD_FAILED',
+    'PWENC_BLOCK_SIZE',
+]
 
 DEFAULT_SECRET_PATH: str
+
+# Error codes
+PWENC_SUCCESS: int
+PWENC_ERROR_INVALID_INPUT: int
+PWENC_ERROR_MEMORY: int
+PWENC_ERROR_CRYPTO: int
+PWENC_ERROR_IO: int
+PWENC_ERROR_SECRET_NOT_FOUND: int
+PWENC_ERROR_PAYLOAD_TOO_LARGE: int
+PWENC_ERROR_WATCH_FAILED: int
+PWENC_ERROR_SECRET_RELOAD_FAILED: int
+
+# Buffer size constants
+PWENC_BLOCK_SIZE: int
 
 class PwencError(RuntimeError):
     """

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -1,0 +1,187 @@
+import os
+import tempfile
+import shutil
+import pytest
+import truenas_pypwenc
+
+
+@pytest.fixture
+def temp_secret_dir():
+    """Create a temporary directory for test secrets."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield tmpdir
+
+
+@pytest.fixture
+def secret_path(temp_secret_dir):
+    """Create a secret path in the temporary directory."""
+    return os.path.join(temp_secret_dir, "test_secret")
+
+
+def test_watch_enabled():
+    """Test that watch flag enables watching."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        secret_path = os.path.join(tmpdir, "test_secret")
+
+        # Create context without watch
+        ctx_no_watch = truenas_pypwenc.get_context(create=True, watch=False, secret_path=secret_path)
+        assert ctx_no_watch.watching is False
+
+        # Create context with watch
+        ctx_with_watch = truenas_pypwenc.get_context(create=False, watch=True, secret_path=secret_path)
+        assert ctx_with_watch.watching is True
+
+
+def test_watch_file_renamed_over(secret_path):
+    """Test that encrypting/decrypting works when secret file is atomically replaced (renamed over)."""
+    # Create initial secret and context with watch
+    ctx = truenas_pypwenc.get_context(create=True, watch=True, secret_path=secret_path)
+    assert ctx.watching is True
+
+    # Encrypt some data with original secret
+    test_data = b"Test data before secret change"
+    encrypted1 = ctx.encrypt(test_data)
+
+    # Verify we can decrypt with original secret
+    decrypted1 = ctx.decrypt(encrypted1)
+    assert decrypted1 == test_data
+
+    # Generate a new secret file and atomically replace the old one
+    temp_secret = secret_path + ".new"
+    # Create a new context to generate a new secret
+    ctx_new = truenas_pypwenc.get_context(create=True, watch=False, secret_path=temp_secret)
+
+    # Encrypt data with new secret to verify it's different
+    encrypted_new = ctx_new.encrypt(test_data)
+
+    # Atomically replace old secret with new secret (rename over)
+    os.rename(temp_secret, secret_path)
+
+    # Now encrypt with the original context - should use new secret after reload
+    encrypted2 = ctx.encrypt(test_data)
+
+    # encrypted2 should be decryptable by ctx_new (which has the new secret)
+    decrypted_by_new = ctx_new.decrypt(encrypted2)
+    assert decrypted_by_new == test_data
+
+    # encrypted1 (from old secret) should NOT be decryptable anymore
+    # This will fail because the secret changed
+    with pytest.raises(Exception):
+        ctx.decrypt(encrypted1)
+
+
+def test_watch_file_renamed(secret_path):
+    """Test that encrypting/decrypting fails when secret file is moved away."""
+    # Create initial secret and context with watch
+    ctx = truenas_pypwenc.get_context(create=True, watch=True, secret_path=secret_path)
+    assert ctx.watching is True
+
+    # Encrypt some data with original secret
+    test_data = b"Test data before secret move"
+    encrypted = ctx.encrypt(test_data)
+    decrypted = ctx.decrypt(encrypted)
+    assert decrypted == test_data
+
+    # Move the secret file away (not replaced)
+    moved_path = secret_path + ".moved"
+    os.rename(secret_path, moved_path)
+
+    # Try to encrypt - should fail because secret file is gone
+    with pytest.raises(Exception) as exc_info:
+        ctx.encrypt(test_data)
+
+    # Verify error is about missing file or reload failure
+    error_msg = str(exc_info.value).lower()
+    assert "not found" in error_msg or "reload" in error_msg or "open" in error_msg
+
+
+def test_watch_file_deleted(secret_path):
+    """Test that encrypting/decrypting fails when secret file is deleted."""
+    # Create initial secret and context with watch
+    ctx = truenas_pypwenc.get_context(create=True, watch=True, secret_path=secret_path)
+    assert ctx.watching is True
+
+    # Encrypt some data with original secret
+    test_data = b"Test data before secret deletion"
+    encrypted = ctx.encrypt(test_data)
+    decrypted = ctx.decrypt(encrypted)
+    assert decrypted == test_data
+
+    # Delete the secret file
+    os.unlink(secret_path)
+
+    # Try to decrypt - should fail because secret file is gone
+    with pytest.raises(Exception) as exc_info:
+        ctx.decrypt(encrypted)
+
+    # Verify error is about missing file or reload failure
+    error_msg = str(exc_info.value).lower()
+    assert "not found" in error_msg or "reload" in error_msg or "open" in error_msg
+
+
+def test_watch_file_modified(secret_path):
+    """Test that secret is reloaded when file is modified in-place."""
+    # Create initial secret and context with watch
+    ctx = truenas_pypwenc.get_context(create=True, watch=True, secret_path=secret_path)
+    assert ctx.watching is True
+
+    # Encrypt some data with original secret
+    test_data = b"Test data before secret modification"
+    encrypted1 = ctx.encrypt(test_data)
+    decrypted1 = ctx.decrypt(encrypted1)
+    assert decrypted1 == test_data
+
+    # Generate a new secret at a different location
+    temp_secret = secret_path + ".new"
+    ctx_new = truenas_pypwenc.get_context(create=True, watch=False, secret_path=temp_secret)
+
+    # Copy the new secret over the old one (this triggers IN_MODIFY)
+    shutil.copy2(temp_secret, secret_path)
+
+    # Now encrypt with the original context - should use new secret after reload
+    encrypted2 = ctx.encrypt(test_data)
+
+    # encrypted2 should be decryptable by ctx_new (which has the new secret)
+    decrypted_by_new = ctx_new.decrypt(encrypted2)
+    assert decrypted_by_new == test_data
+
+    # Old encrypted data should no longer decrypt
+    with pytest.raises(Exception):
+        ctx.decrypt(encrypted1)
+
+
+def test_watch_no_reload_when_file_unchanged(secret_path):
+    """Test that operations work normally when file hasn't changed."""
+    # Create initial secret and context with watch
+    ctx = truenas_pypwenc.get_context(create=True, watch=True, secret_path=secret_path)
+    assert ctx.watching is True
+
+    # Encrypt and decrypt multiple times without changing the file
+    test_data = b"Test data with no file changes"
+
+    for i in range(5):
+        encrypted = ctx.encrypt(test_data)
+        decrypted = ctx.decrypt(encrypted)
+        assert decrypted == test_data
+
+
+def test_watch_decrypt_after_reload(secret_path):
+    """Test that decrypt works with new secret after reload."""
+    # Create initial secret and context with watch
+    ctx = truenas_pypwenc.get_context(create=True, watch=True, secret_path=secret_path)
+    assert ctx.watching is True
+
+    # Replace secret with a new one
+    temp_secret = secret_path + ".new"
+    ctx_new = truenas_pypwenc.get_context(create=True, watch=False, secret_path=temp_secret)
+
+    # Encrypt with the new secret
+    test_data = b"Test data with new secret"
+    encrypted_new = ctx_new.encrypt(test_data)
+
+    # Replace old secret with new one
+    os.rename(temp_secret, secret_path)
+
+    # Original context should now be able to decrypt data encrypted with new secret
+    decrypted = ctx.decrypt(encrypted_new)
+    assert decrypted == test_data


### PR DESCRIPTION
If watch=True (on python API) then the library sets an inotify watch on the file and parent directory to catch situations where:

1. file renamed over
2. file deleted
3. file renamed

If reload is determined necessary then the in-memory secret will be replaced with contents of new file.