### PR TITLE
NAS-139750 / 26.0.0-BETA.1 / Loosen validation to allow empty-string encryption

### DIFF
--- a/src/pwenc/pwenc_encrypt.c
+++ b/src/pwenc/pwenc_encrypt.c
@@ -106,7 +106,9 @@ pwenc_resp_t pwenc_encrypt(pwenc_ctx_t *ctx, const pwenc_datum_t *data_in,
 	pwenc_datum_t nonce = {0};
 	pwenc_resp_t ret = PWENC_SUCCESS;
 
-	if (!ctx || ctx->secret_mem == NULL || !PWENC_DATUM_VALID(data_in) || !data_out) {
+	/* Validate input parameters. Note: we allow empty strings (size == 0) for encryption,
+	 * as they may be needed for cases like storing placeholder values in databases. */
+	if (!ctx || ctx->secret_mem == NULL || !data_in || !data_in->data || !data_out) {
 		pwenc_set_error(error, "invalid input parameters");
 		return PWENC_ERROR_INVALID_INPUT;
 	}

--- a/tests/test_pwenc.py
+++ b/tests/test_pwenc.py
@@ -42,12 +42,20 @@ def test_encrypt_decrypt_various_data(test_data):
     assert decrypted == test_data
 
 
-def test_empty_data_raises_exception():
-    """Test that empty data raises an exception."""
+def test_empty_data_encryption():
+    """Test that empty data can be encrypted and decrypted.
+
+    Empty strings are allowed for encryption to support use cases like
+    storing placeholder values in databases (e.g., revoked API keys).
+    """
     ctx = truenas_pypwenc.get_context(create=True)
 
-    with pytest.raises(Exception):
-        ctx.encrypt(b"")
+    encrypted = ctx.encrypt(b"")
+    assert isinstance(encrypted, bytes)
+    assert len(encrypted) > 0  # Should have nonce + base64 encoding
+
+    decrypted = ctx.decrypt(encrypted)
+    assert decrypted == b""
 
 
 def test_context_attributes():


### PR DESCRIPTION
We need to allow empty strings to be encrypted. The output here is not simply b'' because we pass a nonce along with the empty string to the openssl library. This is required to support middleware pwenc behavior of `encrypt("")`.